### PR TITLE
Mergen changes from RPM::Push module

### DIFF
--- a/lib/Dist/Zilla/Plugin/RPM.pm
+++ b/lib/Dist/Zilla/Plugin/RPM.pm
@@ -3,7 +3,7 @@ package Dist::Zilla::Plugin::RPM;
 
 use Moose;
 use Moose::Autobox;
-use Moose::Util::TypeConstraints qw(enum);
+use Moose::Util::TypeConstraints;
 use namespace::autoclean;
 
 # VERSION
@@ -35,10 +35,23 @@ has ignore_build_deps => (
     default => 0,
 );
 
+has push_packages => ( is => 'ro', isa => 'Bool', default => 0 );
+has push_command => ( is => 'ro', isa => 'Str', default => 'rhnpush -s' );
+
+use constant _CoercedRegexp => do {
+    my $tc = subtype as 'RegexpRef';
+    coerce $tc, from 'Str', via { qr/$_/ };
+    $tc;
+};
+
+has push_ignore_packages => (
+    is      => 'ro', isa => _CoercedRegexp, coerce => 1, default => '.src.rpm$' );
+
 use Carp;
 use File::Temp ();
 use Path::Class qw(dir);
 use Text::Template ();
+use IPC::Run;
 
 sub prune_files {
     my($self) = @_;
@@ -51,41 +64,160 @@ sub prune_files {
     return;
 }
 
+has '_rpmbuild_options' => (
+  is => 'ro', isa => 'ArrayRef[Str]', lazy => 1,
+  default => sub {
+    my $self = shift;
+    return( [
+      $self->sign ? '--sign' : (),
+      $self->ignore_build_deps ? '--nodeps' : (),
+    ] );
+  },
+);
+
+has '_rpmbuild_stage' => (
+  is => 'ro', isa => 'Str', lazy => 1,
+  default => sub {
+    my $self = shift;
+
+    if ($self->build eq 'source') {
+      return('-bs');
+    } elsif ($self->build eq 'all') {
+      return('-ba');
+    }
+
+    $self->log_fatal(q{invalid build type }.$self->build);
+  },
+);
+
+has '_rpmbuild_command' => (
+  is => 'ro',
+  isa => 'ArrayRef[Str]',
+  lazy => 1,
+  default => sub {
+    my $self = shift;
+    return( [
+      'rpmbuild',
+      $self->_rpmbuild_stage,
+      @{$self->_rpmbuild_options},
+      $self->_tmpspecfile->stringify,
+    ] );
+  },
+);
+
+has '_tmpdir' => (
+  is => 'ro', isa => 'File::Temp::Dir', lazy => 1,
+  default => sub {
+    my $self = shift;
+    return File::Temp->newdir();
+  },
+);
+
+has '_tmpspecfile' => (
+  is => 'ro', isa => 'Path::Class::File', lazy => 1,
+  default => sub {
+    my $self = shift;
+        return dir($self->_tmpdir)->file($self->zilla->name . '.spec');
+  },
+);
+
+sub _write_spec {
+  my ($self, $archive) = @_;
+  my $fh = $self->_tmpspecfile->openw();
+  $fh->print($self->mk_spec($archive));
+  $fh->flush;
+  $fh->close;
+  return;
+}
+
+has '_sourcedir' => (
+  is => 'ro', isa => 'Str', lazy => 1,
+  default => sub {
+    my $self = shift;
+    my $sourcedir = qx/rpm --eval '%{_sourcedir}'/
+      or $self->log_fatal(q{couldn't determine RPM sourcedir});
+    $sourcedir =~ s/[\r\n]+$//;
+    $sourcedir .= '/';
+    return($sourcedir);
+  },
+);
+
 sub release {
     my($self,$archive) = @_;
 
-    my $tmpdir  = File::Temp->newdir();
-    my $tmpfile = dir($tmpdir)->file($self->zilla->name . '.spec');
-    my $tmp = $tmpfile->openw();
-    $tmp->print($self->mk_spec($archive));
-    $tmp->flush;
+    $self->_write_spec($archive);
 
-    my $sourcedir = qx/rpm --eval '%{_sourcedir}'/
-        or $self->log_fatal(q{couldn't determine RPM sourcedir});
-    $sourcedir =~ s/[\r\n]+$//;
-    $sourcedir .= '/';
-    system('cp',$archive,$sourcedir)
+    if(! -f $archive ) {
+      $self->log_fatal('archive '.$archive.' does not exist!');
+    }
+
+    system('cp',$archive,$self->_sourcedir)
         && $self->log_fatal('cp failed');
 
-    my @cmd = qw/rpmbuild/;
-    if ($self->build eq 'source') {
-        push @cmd, qw/-bs/;
-    } elsif ($self->build eq 'all') {
-        push @cmd, qw/-ba/;
-    } else {
-        $self->log_fatal(q{invalid build type }.$self->build);
-    }
-    push @cmd, qw/--sign/   if $self->sign;
-    push @cmd, qw/--nodeps/ if $self->ignore_build_deps;
-    push @cmd, "$tmpfile";
-
     if ($ENV{DZIL_PLUGIN_RPM_TEST}) {
-        $self->log("test: would have executed @cmd");
-    } else {
-        system(@cmd) && $self->log_fatal('rpmbuild failed');
+        $self->log("test: would have executed ".join(' ', @{$self->_rpmbuild_command}));
+        return;
+    }
+
+    $self->_execute_rpmbuild;
+    $self->log('RPMs build: '.join(', ', @{$self->_packages_build} ));
+
+    if( $self->push_packages ) {
+        $self->_execute_push_command;
     }
 
     return;
+}
+
+has '_packages_build' => ( is => 'ro', isa => 'ArrayRef[Str]', lazy => 1,
+  default => sub { [] }
+);
+
+sub _execute_rpmbuild {
+  my $self = shift;
+  my ($in, $out, $err);
+  my $lang = $ENV{'LANG'};
+  $ENV{'LANG'} = 'C';
+  $self->log('building RPM...');
+  IPC::Run::run( $self->_rpmbuild_command, \$in, \$out, \$err )
+    or $self->log_fatal('rpmbuild failed: '.$err);
+  foreach my $line ( split(/\n/, $out ) ) {
+    if( $line =~ m/^Wrote: (.*)$/) {
+      push(@{$self->_packages_build}, $1);
+    }
+  }
+  $ENV{'LANG'} = $lang;
+  return;
+}
+
+has _packages_to_push => (
+  is => 'ro', isa => 'ArrayRef[Str]', lazy => 1,
+  default => sub {
+    my $self = shift;
+    my $regex = $self->push_ignore_packages;
+    return( [ grep { $_ !~ m/$regex/ } @{$self->_packages_build} ] );
+  },
+);
+
+has _push_command => (
+  is => 'ro', isa => 'ArrayRef', lazy => 1,
+  default => sub {
+    my $self = shift;
+    return( [ split(/ /, $self->push_command) ] );
+  },
+);
+
+sub _execute_push_command {
+  my $self = shift;
+  my ($in, $out, $err);
+
+  $in = join("\n", @{$self->_packages_to_push});
+
+  $self->log('pushing packages: '.join(', ', @{$self->_packages_to_push}));
+  IPC::Run::run( $self->_push_command, \$in, \$out, $err )
+    or $self->log_fatal('push command failed: '.$err);
+
+  return;
 }
 
 sub mk_spec {
@@ -114,7 +246,14 @@ In your dist.ini:
     sign = 1
     ignore_build_deps = 0
 
-After adding the [RPM] section to the dist.ini file, the mkrpmspec command will be available. Running this command allow you to make the dzil.spec file from the template. Then dzil release will make the RPM file.
+    push_packages = 0
+    push_command = rhnpush -s
+    push_ignore_packages = .src.rpm$
+
+After adding the [RPM] section to the dist.ini file, the mkrpmspec command will be available. Running this command allow you to make the dzil.spec file from the template. Then dzil release will build the RPM file.
+
+It keeps track of build RPM files and can be used to push generated
+packages into a repository.
     
 =head1 DESCRIPTION
 
@@ -159,6 +298,19 @@ If set to a true value, rpmbuild will be called with the --sign option.
 =item ignore_build_deps (default: False)
 
 If set to a true value, rpmbuild will be called with the --nodeps option.
+
+=item push_packages (default: false)
+
+This allowes you to specify a command to push your generated RPM packages to a repository.
+RPM filenames are writen one-per-line to stdin.
+
+=item push_command (default: rhnpush -s)
+
+Command used to push packages.
+
+=item push_ignore_packages (default: .src.rpm$)
+
+A regular expression for packages which should NOT be pushed.
 
 =back
 

--- a/t/02release.t
+++ b/t/02release.t
@@ -18,12 +18,18 @@ use Test::DZil qw(Builder simple_ini);
 
 local $ENV{DZIL_PLUGIN_RPM_TEST} = 1;
 
+our $basic_bundle = [ '@Filter', {
+  '-bundle' => '@Basic',
+  '-remove' => [ 'TestRelease', 'ConfirmRelease', 'UploadToCPAN' ],
+} ];
+
 {
     my $tzil = Builder->from_config(
         { dist_root => 'corpus/dist' },
         {
             add_files => {
                 'source/dist.ini' => simple_ini(
+                    $basic_bundle,
                     'RPM'
                 ),
             },
@@ -43,6 +49,7 @@ local $ENV{DZIL_PLUGIN_RPM_TEST} = 1;
         {
             add_files => {
                 'source/dist.ini' => simple_ini(
+                    $basic_bundle,
                     ['RPM' => {
                         sign => 1
                     }],
@@ -64,6 +71,7 @@ local $ENV{DZIL_PLUGIN_RPM_TEST} = 1;
         {
             add_files => {
                 'source/dist.ini' => simple_ini(
+                    $basic_bundle,
                     ['RPM' => {
                         ignore_build_deps => 1
                     }],
@@ -85,6 +93,7 @@ local $ENV{DZIL_PLUGIN_RPM_TEST} = 1;
         {
             add_files => {
                 'source/dist.ini' => simple_ini(
+                    $basic_bundle,
                     ['RPM' => {
                         build => 'source'
                     }],


### PR DESCRIPTION
The module Dist::Zilla::Plugin::RPM::Push was a fork of this module.
This commit tries to merge back the added push feature.

It adds the following options to Dist::Zilla::Plugin::RPM:

  push_packages = 0
  push_command = rhnpush -s
  push_ignore_packages = .src.rpm$

The commit will change the execution of rpmbuild to capture the output
and parses it to find the rpm build artefacts.

If push_packages is set to enabled(1) it will execute the push_command
on the generated RPMs. By default the source packages will be excluded.

closes #2