### PR TITLE
convert deprecated path call to Path::Tiny

### DIFF
--- a/lib/Dist/Zilla/Plugin/RPM.pm
+++ b/lib/Dist/Zilla/Plugin/RPM.pm
@@ -4,6 +4,7 @@ package Dist::Zilla::Plugin::RPM;
 use Moose;
 use Moose::Autobox;
 use Moose::Util::TypeConstraints;
+use Path::Tiny;
 use namespace::autoclean;
 
 # VERSION
@@ -229,7 +230,7 @@ sub mk_spec {
     my($self,$archive) = @_;
     my $t = Text::Template->new(
         TYPE       => 'FILE',
-        SOURCE     => $self->zilla->root->file($self->spec_file),
+        SOURCE     => path($self->zilla->root)->child($self->spec_file),
         DELIMITERS => [ '<%', '%>' ],
     ) || $self->log_fatal($Text::Template::ERROR);
     return $t->fill_in(


### PR DESCRIPTION
Current version spits a deprecation warning with Dist::Zilla 6.x:

->file called on a Dist::Zilla::Path object; this will cease to work in Dist::Zilla v7; downstream code should be updated to use Path::Tiny API, not Path::Class at /home/joe/.plenv/versions/5.24.1/lib/perl5/site_perl/5.24.1/Dist/Zilla/Plugin/RPM.pm line 230.

This tiny patch corrects that by using Path::Tiny. As far as I know it doesn't effect anything else, it generates spec files without warnings, and the tests pass.